### PR TITLE
Fixes mismatching title/artist/album tags while getting metadata

### DIFF
--- a/processLyrics.js
+++ b/processLyrics.js
@@ -33,23 +33,23 @@ const headers = {
 
 function getMetadata(filePath) {
     try {
-	    const fields = {
-	    	title: '',
-	    	artist: '',
-	    	album: ''
-	    };
+        const fields = {
+            title: '',
+            artist: '',
+            album: ''
+        };
 
         const ffprobeCommand = `ffprobe -v quiet -show_entries format_tags=artist,album,title "${filePath}"`;
-	    const ffprobeOutput = execSync(ffprobeCommand, { encoding: 'utf8' });
+        const ffprobeOutput = execSync(ffprobeCommand, { encoding: 'utf8' });
 
-	    ffprobeOutput.split('\n').forEach(line => {
-		    const match = line.match(/^TAG:(TITLE|ARTIST|ALBUM)=(.*)$/);
-		    if (match) {
+        ffprobeOutput.split('\n').forEach(line => {
+            const match = line.match(/^TAG:(TITLE|ARTIST|ALBUM)=(.*)$/);
+            if (match) {
                 const propertyName = match[1].toLowerCase();
                 const propertyValue = match[2];
-		        fields[propertyName] = propertyValue;
-		    }
-	    });
+                fields[propertyName] = propertyValue;
+            }
+        });
 
         if (Object.keys(fields).length === 3) {
             return fields;


### PR DESCRIPTION
Hi! I got a an error where it wasn't able to get the lyrics to my files which I though was strange, and noticed that it didn't correctly map the tags to their values. For example the album name was assigned to the artist tag, the title tag to the album tag etc.

I fixed it and also made assigning the values a bit more robust if somehow the order gets changed around in the future. 

This is my first time committing to a git repo so I hope I'm doing this right. Let me know!